### PR TITLE
Implement minimal TypeScript CRM skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# verticaltest
+# Vertical Test CRM
+
+This repository contains a minimal CRM prototype written in TypeScript. The project uses a vertical slice approach with event sourcing. The current implementation exposes a single API endpoint to create a client.
+
+## Running
+
+Use the TypeScript compiler to build the project:
+
+```bash
+tsc
+```
+
+Start the generated JavaScript server:
+
+```bash
+node dist/index.js
+```
+
+The server listens on `http://localhost:8080`.
+
+## API
+
+`POST /client/create`
+
+Request body:
+
+```json
+{
+  "name": "Jane Doe",
+  "email": "jane@example.com"
+}
+```
+
+Response body is a `ClientCreated` event containing the assigned identifier and the provided data.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "verticaltest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/client/create.ts
+++ b/src/client/create.ts
@@ -1,0 +1,29 @@
+export interface CreateClientCommand {
+  name: string;
+  email: string;
+}
+
+export interface ClientCreatedEvent {
+  type: 'ClientCreated';
+  payload: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+export function createClient(command: CreateClientCommand): ClientCreatedEvent {
+  const id = generateId();
+  return {
+    type: 'ClientCreated',
+    payload: {
+      id,
+      name: command.name,
+      email: command.email,
+    },
+  };
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}

--- a/src/http.d.ts
+++ b/src/http.d.ts
@@ -1,0 +1,17 @@
+declare module 'http' {
+  interface IncomingMessage {
+    method?: string;
+    url?: string;
+    on(event: string, listener: (chunk: any) => void): void;
+  }
+
+  interface ServerResponse {
+    setHeader(name: string, value: string): void;
+    writeHead(status: number): void;
+    end(data?: string): void;
+  }
+
+  function createServer(
+    requestListener: (req: IncomingMessage, res: ServerResponse) => void
+  ): { listen(port: number, callback?: () => void): void };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,32 @@
+import http from 'http';
+import { createClient, CreateClientCommand } from './client/create';
+
+const PORT = 8080;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/client/create') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const command: CreateClientCommand = JSON.parse(body);
+        const event = createClient(command);
+        res.setHeader('Content-Type', 'application/json');
+        res.writeHead(200);
+        res.end(JSON.stringify(event));
+      } catch (err) {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": false,
+    "esModuleInterop": true,
+    "lib": [
+      "es2019",
+      "dom"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- initialize npm project with TypeScript build config
- add client creation vertical slice and HTTP server
- document how to run the server and API usage

## Testing
- `npm run build`
- `node dist/index.js &`
- `curl -X POST -d '{"name":"Alice","email":"alice@example.com"}' http://localhost:8080/client/create`

------
https://chatgpt.com/codex/tasks/task_e_684c1280dbf883288bb8aece6e4f4eea