### PR TITLE
Publish ClientCreated events to Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ node dist/index.js
 
 The server listens on `http://localhost:8080`.
 
+The application expects a Kafka broker running on `localhost:9092`. Events are
+published to the `client-events` topic when a new client is created.
+
 ## API
 
 `POST /client/create`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "tsc",
     "start": "node dist/index.js"
   },
+  "dependencies": {
+    "kafkajs": "^2.4.1"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,24 @@
 import http from 'http';
 import { createClient, CreateClientCommand } from './client/create';
+import { initKafka, publishEvent } from './kafka';
 
 const PORT = 8080;
 
-const server = http.createServer((req, res) => {
+const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && req.url === '/client/create') {
     let body = '';
     req.on('data', chunk => {
       body += chunk;
     });
-    req.on('end', () => {
+    req.on('end', async () => {
       try {
         const command: CreateClientCommand = JSON.parse(body);
         const event = createClient(command);
+        try {
+          await publishEvent('client-events', event);
+        } catch (err) {
+          console.error('Failed to publish event', err);
+        }
         res.setHeader('Content-Type', 'application/json');
         res.writeHead(200);
         res.end(JSON.stringify(event));
@@ -27,6 +33,12 @@ const server = http.createServer((req, res) => {
   }
 });
 
-server.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+initKafka()
+  .then(() => {
+    server.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  })
+  .catch(err => {
+    console.error('Unable to initialize Kafka', err);
+  });

--- a/src/kafka.ts
+++ b/src/kafka.ts
@@ -1,0 +1,19 @@
+import { Kafka } from 'kafkajs';
+
+const kafka = new Kafka({
+  clientId: 'crm',
+  brokers: ['localhost:9092'],
+});
+
+const producer = kafka.producer();
+
+export async function initKafka(): Promise<void> {
+  await producer.connect();
+}
+
+export async function publishEvent(topic: string, event: unknown): Promise<void> {
+  await producer.send({
+    topic,
+    messages: [{ value: JSON.stringify(event) }],
+  });
+}

--- a/src/kafkajs.d.ts
+++ b/src/kafkajs.d.ts
@@ -1,0 +1,11 @@
+declare module 'kafkajs' {
+  export class Kafka {
+    constructor(config: { clientId: string; brokers: string[] });
+    producer(): Producer;
+  }
+
+  export interface Producer {
+    connect(): Promise<void>;
+    send(payload: { topic: string; messages: { value: string }[] }): Promise<void>;
+  }
+}


### PR DESCRIPTION
## Summary
- add kafkajs dependency and minimal type declaration
- create basic Kafka producer helper
- send event from the HTTP controller
- document Kafka requirement in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c14b2d14883289df22ac835aaa211